### PR TITLE
Can return null

### DIFF
--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -191,6 +191,9 @@ final class Plugin implements PluginInterface, EventSubscriberInterface {
         $this->serviceProvidersFromExtraSpi($composer->getPackage(), $mappings);
         $this->serviceProvidersFromAutoloadFiles($composer->getPackage(), $mappings, Platform::getCwd(), $io);
         foreach ($composer->getRepositoryManager()->getLocalRepository()->getPackages() as $package) {
+            if ($composer->getInstallationManager()->getInstallPath($package) === null) {
+                continue;
+            }
             $this->serviceProvidersFromExtraSpi($package, $mappings);
             $this->serviceProvidersFromAutoloadFiles($package, $mappings, $composer->getInstallationManager()->getInstallPath($package), $io);
         }


### PR DESCRIPTION
 [TypeError]                                                                                                                                                                                                
  Nevay\SPI\Composer\Plugin::serviceProvidersFromAutoloadFiles(): Argument #3 ($installPath) must be of type string, null given, called in /srv/www/vendor/tbachert/spi/src/Composer/Plugin.php on line 198